### PR TITLE
Simplified Level Calculation logic.

### DIFF
--- a/src/main/java/rebelmythik/antivillagerlag/utils/CalculateLevel.java
+++ b/src/main/java/rebelmythik/antivillagerlag/utils/CalculateLevel.java
@@ -4,33 +4,18 @@ import org.bukkit.entity.Villager;
 
 public class CalculateLevel {
     public static long villagerEXP (Villager vil) {
+        
         int vilEXP = vil.getVillagerExperience();
-        int vilLVL = vil.getVillagerLevel();
-
-        // Level 2 Calculation
-        if (vilLVL == 1 && vilEXP < 10) return 1;
-        if (vilLVL == 1 && vilEXP >= 10 && vilEXP < 70) return 2;
-        if (vilLVL == 1 && vilEXP >= 70 && vilEXP < 150) return 3;
-        if (vilLVL == 1 && vilEXP >= 150 && vilEXP < 250) return 4;
-        if (vilLVL == 1 && vilEXP >= 250) return 5;
-
-        // Level 3 Calculation
-        if (vilLVL == 2 && vilEXP >= 10 && vilEXP < 70) return 2;
-        if (vilLVL == 2 && vilEXP >= 70 && vilEXP < 150) return 3;
-        if (vilLVL == 2 && vilEXP >= 150 && vilEXP < 250) return 4;
-        if (vilLVL == 2 && vilEXP >= 250) return 5;
-
-        // Level 4 Calculation
-        if (vilLVL == 3 && vilEXP >= 70 && vilEXP < 150) return 3;
-        if (vilLVL == 3 && vilEXP >= 150 && vilEXP < 250) return 4;
-        if (vilLVL == 3 && vilEXP >= 250) return 5;
-
-        //Level 5 Calculation
-        if (vilLVL == 4 && vilEXP >= 150 && vilEXP < 250) return 4;
-        if (vilLVL == 4 && vilEXP >= 250) return 5;
-
-        if (vilLVL == 5 && vilEXP >= 250) return 5;
-
-        return 0;
+            
+        // Villager Level depending on their XP
+        // source: https://minecraft.fandom.com/wiki/Trading#Mechanics
+        
+        if (vilEXP >= 250) return 5;
+        if (vilEXP >= 150) return 4;
+        if (vilEXP >= 70) return 3;
+        if (vilEXP >= 10) return 2;
+        
+        // default level is 1
+        return 1;
     }
 }


### PR DESCRIPTION
Looking online it doesn't seem like EXP gets set to 0 after leveling up, so it's unnecessary to check Villager level.
This makes the code a lot easier to maintain and understand.