### PR TITLE
Fix commands and add ClearName feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>rebelmythik</groupId>
     <artifactId>AntiVillagerLag</artifactId>
-    <version>2.1.1</version>
+    <version>2.2.0</version>
     <packaging>jar</packaging>
 
     <name>AntiVillagerLag</name>

--- a/src/main/java/rebelmythik/antivillagerlag/AntiVillagerLag.java
+++ b/src/main/java/rebelmythik/antivillagerlag/AntiVillagerLag.java
@@ -3,6 +3,8 @@ package rebelmythik.antivillagerlag;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.MultiLineChart;
 import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.PluginCommand;
 import org.bukkit.configuration.Configuration;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -10,6 +12,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import rebelmythik.antivillagerlag.commands.RadiusOptimizeCommand;
 import rebelmythik.antivillagerlag.commands.ReloadCommand;
 import rebelmythik.antivillagerlag.events.EventListenerHandler;
+import rebelmythik.antivillagerlag.utils.ColorCode;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,8 +25,15 @@ public final class AntiVillagerLag extends JavaPlugin {
     public void onEnable() {
         // Plugin startup logic
         this.getServer().getPluginManager().registerEvents(new EventListenerHandler(this),this);
+        ColorCode colorcodes = new ColorCode();
+
         getCommand("avlreload").setExecutor(new ReloadCommand(this));
+        getCommand("avlreload").setPermissionMessage(colorcodes.cm(this.getConfig().getString("messages.no-permission")));
+
         getCommand("avloptimize").setExecutor(new RadiusOptimizeCommand(this));
+        getCommand("avloptimize").setPermissionMessage(colorcodes.cm(this.getConfig().getString("messages.no-permission")));
+
+
         saveDefaultConfig();
         updateConfig();
 

--- a/src/main/java/rebelmythik/antivillagerlag/commands/RadiusOptimizeCommand.java
+++ b/src/main/java/rebelmythik/antivillagerlag/commands/RadiusOptimizeCommand.java
@@ -34,7 +34,6 @@ public class RadiusOptimizeCommand implements CommandExecutor {
 
         String playerName = sender.getName();
 
-        if (cmd.getName().equalsIgnoreCase("avloptimize")) {
             if(!sender.hasPermission("avl.optimize")) {
                 sender.sendMessage(colorcodes.cm(plugin.getConfig().getString("messages.no-permission")));
                 return true;
@@ -57,7 +56,7 @@ public class RadiusOptimizeCommand implements CommandExecutor {
                     sender.sendMessage(colorcodes.cm(plugin.getConfig().getString("messages.radius-limit")));
                     return false;
                 }
-
+                int count = 0;
                 for (Entity entity : Bukkit.getPlayer(playerName).getNearbyEntities(radius, radius, radius)) {
                     Entity vil = entity;
                     if (entity instanceof Villager) {
@@ -80,12 +79,14 @@ public class RadiusOptimizeCommand implements CommandExecutor {
                             // set all necessary flags and timers
                             VillagerUtilities.setMarker((Villager) vil, plugin);
                             VillagerUtilities.setNewCooldown((Villager) vil, plugin, cooldown);
+                            count++;
                         }
 
                     }
                 }
+                sender.sendMessage(colorcodes.cm("&aOptimized "+count+" villagers!"));
             }
-        }
-        return false;
+
+        return true;
     }
 }

--- a/src/main/java/rebelmythik/antivillagerlag/commands/ReloadCommand.java
+++ b/src/main/java/rebelmythik/antivillagerlag/commands/ReloadCommand.java
@@ -15,14 +15,10 @@ public class ReloadCommand implements CommandExecutor {
         this.plugin = plugin;
     }
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
-        if (cmd.getName().equalsIgnoreCase("avlreload")) {
-            if(!sender.hasPermission("avl.reload")) {
-                sender.sendMessage(colorcodes.cm(plugin.getConfig().getString("messages.no-permission")));
-                return true;
-            }
+
             sender.sendMessage(colorcodes.cm(plugin.getConfig().getString("messages.reload-message")));
             plugin.reloadConfig();
-        }
-        return false;
+
+        return true;
     }
 }

--- a/src/main/java/rebelmythik/antivillagerlag/events/NameTagAI.java
+++ b/src/main/java/rebelmythik/antivillagerlag/events/NameTagAI.java
@@ -1,10 +1,12 @@
 package rebelmythik.antivillagerlag.events;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.scheduler.BukkitScheduler;
 import rebelmythik.antivillagerlag.AntiVillagerLag;
 import rebelmythik.antivillagerlag.utils.ColorCode;
 import rebelmythik.antivillagerlag.utils.VillagerUtilities;
@@ -81,6 +83,9 @@ public class NameTagAI {
             // set all necessary flags and timers
             VillagerUtilities.setMarker(vil, plugin);
             VillagerUtilities.setNewCooldown(vil, plugin, cooldown);
+
+
+
         } else {
             // Re-Enabling AI
             // Check that the villager is disabled
@@ -98,6 +103,15 @@ public class NameTagAI {
             VillagerUtilities.setNewCooldown(vil, plugin, cooldown);
             // remove the marker again
             VillagerUtilities.removeMarker(vil, plugin);
+
+            if(plugin.getConfig().getBoolean("toggleableoptions.clearnametag.enabled")) {
+                boolean clearName = item.getItemMeta().getDisplayName().equalsIgnoreCase(plugin.getConfig().getString("toggleableoptions.clearnametag.nametag"));
+                if (clearName) {
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        e.getRightClicked().setCustomName(null);
+                    }, 1);
+                }
+            }
         }
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,6 +29,11 @@ toggleableoptions:
   # This will allow a block to disable and renable the Villager AI.
   useblocks: false
 
+  # This lets you remove the name from villagers when you disable their AI if you use a specific tag
+  clearnametag:
+    enabled: false
+    nametag: 'ClearName'
+
 messages:
   no-permission: "&cYou don't have permission to use this command."
   reload-message: "&aPlugin successfully reloaded."

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,8 +6,10 @@ api-version: 1.17
 commands:
   avlreload:
     description: reloads the config
+    permission: avl.reload
   avloptimize:
     description: will disable all the nearby villagers
+    permission: avl.optimize
 
 permissions:
   avl.disable:


### PR DESCRIPTION
Change weird if else code to a more proper way of doing commands and add a counter/command feedback for radius command

Add ClearName Feature

Makes it so that if enabled, when you use a specific nametag name, it removes the custom name from a villager